### PR TITLE
Remove roles ; link to cloud-specific permissions

### DIFF
--- a/concept-cloud-compliance.adoc
+++ b/concept-cloud-compliance.adoc
@@ -202,8 +202,3 @@ When you use BlueXP in SaaS mode, the connection to BlueXP is served over HTTPS,
 Outbound rules are completely open. Internet access is needed to install and upgrade the BlueXP classification software and to send usage metrics.
 
 If you have strict networking requirements, link:task-deploy-cloud-compliance.html#review-prerequisites[learn about the endpoints that BlueXP classification contacts^].
-
-[#user-roles]
-== User roles in BlueXP classification
-
-The role each user has been assigned provides different capabilities within BlueXP and within BlueXP classification. For details, refer to https://docs.netapp.com/us-en/bluexp-setup-admin/reference-iam-predefined-roles.html[BlueXP IAM roles] (when using BlueXP in standard mode).

--- a/task-deploy-cloud-compliance.adoc
+++ b/task-deploy-cloud-compliance.adoc
@@ -189,7 +189,11 @@ Review the appropriate table below depending on whether you are deploying BlueXP
 // end tabbed area
 
 Ensure that BlueXP has the required permissions::
-Ensure that BlueXP has permissions to deploy resources and create security groups for the BlueXP classification instance. You can find the latest BlueXP permissions in https://docs.netapp.com/us-en/bluexp-setup-admin/reference-permissions.html[the policies provided by NetApp^].
+Ensure that BlueXP has permissions to deploy resources and create security groups for the BlueXP classification instance.
+
+* link:https://docs.netapp.com/us-en/bluexp-setup-admin/reference-permissions-gcp.html[Google Cloud permissions^]
+* link:https://docs.netapp.com/us-en/bluexp-setup-admin/reference-permissions-aws.html#classification[AWS permissions^]
+* link:https://docs.netapp.com/us-en/bluexp-setup-admin/reference-permissions-azure.html#classification[Azure permissions^]
 
 Ensure that the BlueXP Connector can access BlueXP classification::
 Ensure connectivity between the Connector and the BlueXP classification instance. The security group for the Connector must allow inbound and outbound traffic over port 443 to and from the BlueXP classification instance. This connection enables deployment of the BlueXP classification instance and enables you to view information in the Compliance and Governance tabs. BlueXP classification is supported in Government regions in AWS and Azure.


### PR DESCRIPTION
This pull request updates the documentation for BlueXP classification to improve clarity and provide more detailed guidance on permissions. The most important changes include removing outdated sections about user roles and adding links to platform-specific permissions for deploying resources.

### Documentation updates:

* **Removed outdated user roles section**: The section on user roles in BlueXP classification was removed from `concept-cloud-compliance.adoc`, as it referenced standard mode and is no longer relevant.
* **Added platform-specific permissions links**: Updated `task-deploy-cloud-compliance.adoc` to include separate links for Google Cloud, AWS, and Azure permissions required for deploying BlueXP classification resources. This improves clarity for users working on different platforms.